### PR TITLE
Restrict GitHub Packages publish to release refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
         run: npm publish fetchclient.tgz --provenance --access public
 
       - name: Setup GitHub CI Node.js environment
-        if: github.event_name != 'pull_request'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         uses: actions/setup-node@v6
         with:
           node-version: "24.x"
@@ -109,7 +109,7 @@ jobs:
           scope: "@foundatiofx"
 
       - name: Push GitHub CI Packages
-        if: github.event_name != 'pull_request'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         run: npm publish fetchclient.tgz --tag ${{ startsWith(github.ref, 'refs/tags/v') && 'latest' || 'next' }} --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Restricts the GitHub Packages publish steps in CI to `main` and version tag refs.

The failing run built `fetchclient.tgz` successfully, then failed publishing `@foundatiofx/fetchclient@1.3.4-alpha.0.2` to GitHub Packages with `E409 Cannot publish over existing version`. Branch push workflows were allowed to publish `next` packages, so a feature/dependency branch could publish the same MinVer prerelease version that `main` later tries to publish after merge.

This keeps package build validation on branch pushes, but prevents non-release branch refs from publishing immutable GitHub Packages versions.