### PR TITLE
Skip duplicate GitHub package publishes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,12 @@ jobs:
 
       - name: Push GitHub CI Packages
         if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
-        run: npm publish fetchclient.tgz --tag ${{ startsWith(github.ref, 'refs/tags/v') && 'latest' || 'next' }} --access public
+        run: |
+          package="@foundatiofx/fetchclient@${{ needs.lint.outputs.version }}"
+          if npm view "$package" version --registry https://npm.pkg.github.com > /dev/null 2>&1; then
+            echo "$package already exists in GitHub Packages; skipping publish."
+          else
+            npm publish fetchclient.tgz --tag ${{ startsWith(github.ref, 'refs/tags/v') && 'latest' || 'next' }} --access public
+          fi
         env:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## Summary

- check GitHub Packages for the computed MinVer package version before publishing
- skip publishing when that immutable version already exists
- preserve failures for missing versions when the actual publish command fails

## Root cause

The main-branch CI run built and tested successfully, then failed publishing `@foundatiofx/fetchclient@1.3.4-alpha.0.4` with `E409 Cannot publish over existing version`.

This applies the npm equivalent of the shared Foundatio .NET workflow's `dotnet nuget push --skip-duplicate` behavior. Package versions and tagged release behavior are unchanged.

Failed run: https://github.com/FoundatioFx/FetchClient/actions/runs/29471432936

## Validation

- `deno task format-check`
- `deno task lint`
- `deno task check`
- `deno task test` (198 passed)
- exercised both shell branches: existing package skips; missing package publishes
- `git diff --check`