### PR TITLE
Fix npm release provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,12 @@ name: CI
 on:
   push:
   workflow_call:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: Version to publish to npm and GitHub Packages
+        required: true
+        type: string
 
 jobs:
   lint:
@@ -20,9 +26,15 @@ jobs:
 
       - name: Build Version
         id: version
+        env:
+          VERSION_OVERRIDE: ${{ inputs.release_version }}
         run: |
-          dotnet tool install --global minver-cli --version 7.0.0
-          version=$(minver --tag-prefix v)
+          if [ -n "$VERSION_OVERRIDE" ]; then
+            version="$VERSION_OVERRIDE"
+          else
+            dotnet tool install --global minver-cli --version 7.0.0
+            version=$(minver --tag-prefix v)
+          fi
           echo "version=$version" >> $GITHUB_OUTPUT
           echo "### Version: $version" >> $GITHUB_STEP_SUMMARY
 
@@ -86,6 +98,21 @@ jobs:
       - name: Build NPM Package
         run: deno task build --set-version ${{ needs.lint.outputs.version }}
 
+      - name: Add NPM Package Metadata
+        env:
+          REPOSITORY_URL: https://github.com/${{ github.repository }}
+        run: |
+          package_dir=$(mktemp -d)
+          tar -xzf fetchclient.tgz -C "$package_dir"
+          PACKAGE_JSON="$package_dir/package/package.json" deno eval '
+            const path = Deno.env.get("PACKAGE_JSON");
+            const repositoryUrl = Deno.env.get("REPOSITORY_URL");
+            const packageJson = JSON.parse(await Deno.readTextFile(path));
+            packageJson.repository = { type: "git", url: repositoryUrl };
+            await Deno.writeTextFile(path, `${JSON.stringify(packageJson, null, 2)}\n`);
+          '
+          tar -czf fetchclient.tgz -C "$package_dir" package
+
       - name: Show NPM Package
         run: tar -xOf fetchclient.tgz package/package.json
 
@@ -97,11 +124,11 @@ jobs:
           scope: "@foundatiofx"
 
       - name: Publish Release Package
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         run: npm publish fetchclient.tgz --provenance --access public
 
       - name: Setup GitHub CI Node.js environment
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         uses: actions/setup-node@v7
         with:
           node-version: "24.x"
@@ -109,13 +136,13 @@ jobs:
           scope: "@foundatiofx"
 
       - name: Push GitHub CI Packages
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         run: |
           package="@foundatiofx/fetchclient@${{ needs.lint.outputs.version }}"
           if npm view "$package" version --registry https://npm.pkg.github.com > /dev/null 2>&1; then
             echo "$package already exists in GitHub Packages; skipping publish."
           else
-            npm publish fetchclient.tgz --tag ${{ startsWith(github.ref, 'refs/tags/v') && 'latest' || 'next' }} --access public
+            npm publish fetchclient.tgz --tag ${{ (startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch') && 'latest' || 'next' }} --access public
           fi
         env:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## Summary

- add the repository metadata npm provenance expects to the tarball generated by `deno pack`
- add an explicit manual recovery input for npm and GitHub Packages releases
- keep JSR publication tag-only so recovering version 1.3.4 cannot republish the already-successful JSR package

## Root cause

The v1.3.4 release workflow built, tested, and published to JSR successfully. npm rejected the generated tarball with `E422` because `package.json.repository.url` was missing and therefore did not match the GitHub repository in the signed provenance bundle.

## Recovery

After this merges, dispatching CI with `release_version=1.3.4` will publish the corrected tarball to npm and GitHub Packages while skipping JSR.

## Validation

- `deno task format-check`
- `deno task lint`
- `deno task check`
- `deno task test` (200 tests)
- corrected tarball contains `repository.url = https://github.com/FoundatioFx/FetchClient`
- `npm publish fetchclient.tgz --dry-run --provenance --access public`